### PR TITLE
fix: Xplorer subdomains not indexing

### DIFF
--- a/indexer/listener.py
+++ b/indexer/listener.py
@@ -54,9 +54,9 @@ class Listener(StarkNetIndexer):
         self.handle_pending_data = self.handle_data
 
     def check_is_subdomain(self, contract: FieldElement):
-        if felt.to_hex(contract) == self.conf.braavos_contract:
+        if felt.to_int(contract) == int(self.conf.braavos_contract, 16):
             return (True, "braavos")
-        elif felt.to_hex(contract) == self.conf.xplorer_contract:
+        elif felt.to_int(contract) == int(self.conf.xplorer_contract, 16):
             return (True, "xplorer")
         else:
             return (False, "")


### PR DESCRIPTION
updates `check_is_subdomain` function which was comparing contract addresses as hexadecimal, which didn't work if there was a difference in 0 at the start of the hex string in config.toml. `check_is_subdomain` now compare contract addresses as int. 