### PR TITLE
feat: index referral events

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -6,6 +6,7 @@ starknetid = "0x0798e884450c19e072d6620fefdbeb7387d0453d3fd51d95f5ace1f17633d88b
 naming = "0x05cf267a0af6101667013fc6bd3f6c11116a14cda9b8c4b1198520d59f900b17"
 braavos = "0x0660b2cd3c93528d4edf790610404414ba3f03e0d45c814d686d628583cb34de"
 xplorer = "0x4942ebdc9fc996a42adb4a825e9070737fe68cef32a64a616ba5528d457812e"
+referral = "0x0"
 
 [apibara]
 indexer_id = "starknet-id"
@@ -14,3 +15,4 @@ starting_block = 396100
 connection_string = "mongodb://apibara:apibara@mongo:27017"
 apibara_stream = "goerli.starknet.a5a.ch:443"
 token="XXXXXXXXXXXXXXXXX"
+is_devnet = false

--- a/indexer/__main__.py
+++ b/indexer/__main__.py
@@ -24,11 +24,13 @@ async def main():
     conf = TomlConfig("config.toml", "config.template.toml")
     create_indexes(conf)
     events_manager = Listener(conf)
+    enable_ssl = False if conf.is_devnet is True else True
     runner = IndexerRunner(
         config=IndexerRunnerConfiguration(
             stream_url=conf.apibara_stream,
             storage_url=conf.connection_string,
-            token=conf.token
+            token=conf.token,
+            stream_ssl=enable_ssl,
         ),
         reset_state=conf.reset_state,
     )

--- a/indexer/config.py
+++ b/indexer/config.py
@@ -33,6 +33,7 @@ class TomlConfig(Config):
         self.naming_contract = contract["naming"]
         self.braavos_contract = contract["braavos"]
         self.xplorer_contract = contract["xplorer"]
+        self.referral_contract = contract["referral"]
 
         apibara = config["apibara"]
         self.indexer_id = apibara["indexer_id"]
@@ -41,3 +42,4 @@ class TomlConfig(Config):
         self.connection_string = apibara["connection_string"]
         self.apibara_stream = apibara["apibara_stream"]
         self.token = apibara["token"]
+        self.is_devnet = apibara["is_devnet"]


### PR DESCRIPTION
This PR closes #28 

It indexes `on_claim` and `on_commission` events from the referral contract. 

To test it on the devnet you can use script `deploy_devnet` here : https://github.com/starknet-id/referral_contract/pull/2 (Explanation to run the script is located in the README file in this PR)